### PR TITLE
Add DsrGetDcNameEx2Response

### DIFF
--- a/lib/ruby_smb/dcerpc/netlogon.rb
+++ b/lib/ruby_smb/dcerpc/netlogon.rb
@@ -67,6 +67,7 @@ module RubySMB
       require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_request'
       require 'ruby_smb/dcerpc/netlogon/netr_server_req_challenge_response'
       require 'ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_request'
+      require 'ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_response'
 
       # Calculate the netlogon session key from the provided shared secret and
       # challenges. The shared secret is an NTLM hash.

--- a/lib/ruby_smb/dcerpc/netlogon/domain_controller_infow.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/domain_controller_infow.rb
@@ -1,0 +1,28 @@
+require 'ruby_smb/dcerpc/ndr'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [2.2.1.2.1 DOMAIN_CONTROLLER_INFOW](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/9b85a7a4-8d34-4b9e-9500-bf8644ebfc06)
+      class DomainControllerInfoW < Ndr::NdrStruct
+        default_parameters byte_align: 4
+        endian :little
+
+        ndr_wide_stringz_ptr :domain_controller_name
+        ndr_wide_stringz_ptr :domain_controller_address
+        ndr_uint32           :domain_controller_address_type
+        uuid                 :domain_guid
+        ndr_wide_stringz_ptr :domain_name
+        ndr_wide_stringz_ptr :dns_forest_name
+        ndr_uint32           :flags
+        ndr_wide_stringz_ptr :dc_site_name
+        ndr_wide_stringz_ptr :client_site_name
+      end
+
+      class DomainControllerInfoWPtr < DomainControllerInfoW
+        extend Ndr::PointerClassPlugin
+      end
+    end
+  end
+end

--- a/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_request.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_request.rb
@@ -4,19 +4,19 @@ module RubySMB
   module Dcerpc
     module Netlogon
 
-      # [3.5.4.3.1 DsrGetDCNameEx2 (Opnum 34)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620)
-      class DsrGetDCNameEx2Request < BinData::Record
+      # [3.5.4.3.1 DsrGetDcNameEx2 (Opnum 34)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620)
+      class DsrGetDcNameEx2Request < BinData::Record
         attr_reader :opnum
 
         endian :little
 
-        logonsrv_handle  :computer_name
-        ndr_wide_stringz_ptr :account_name
-        ndr_uint32 :allowable_account_control_bits
-        ndr_wide_stringz_ptr :domain_name
-        uuid_ptr  :domain_guid
-        ndr_wide_stringz_ptr :site_name
-        ndr_uint32 :flags
+        logonsrv_handle       :computer_name
+        ndr_wide_stringz_ptr  :account_name
+        ndr_uint32            :allowable_account_control_bits
+        ndr_wide_stringz_ptr  :domain_name
+        uuid_ptr              :domain_guid
+        ndr_wide_stringz_ptr  :site_name
+        ndr_uint32            :flags
 
         def initialize_instance
           super

--- a/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_response.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_response.rb
@@ -5,14 +5,14 @@ module RubySMB
   module Dcerpc
     module Netlogon
 
-      # [3.5.4.3.1 DsrGetDCNameEx2 (Opnum 34)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620)
-      class DsrGetDCNameEx2Response < BinData::Record
+      # [3.5.4.3.1 DsrGetDcNameEx2 (Opnum 34)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620)
+      class DsrGetDcNameEx2Response < BinData::Record
         attr_reader :opnum
 
         endian :little
 
-        domain_controller_info_w_ptr :domain_controller_info
-        ndr_uint32                   :error_status
+        domain_controller_info_w_ptr  :domain_controller_info
+        ndr_uint32                    :error_status
 
         def initialize_instance
           super

--- a/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_response.rb
+++ b/lib/ruby_smb/dcerpc/netlogon/dsr_get_dc_name_ex2_response.rb
@@ -1,0 +1,24 @@
+require 'ruby_smb/dcerpc/ndr'
+require 'ruby_smb/dcerpc/netlogon/domain_controller_infow'
+
+module RubySMB
+  module Dcerpc
+    module Netlogon
+
+      # [3.5.4.3.1 DsrGetDCNameEx2 (Opnum 34)](https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-nrpc/fb8e1146-a045-4c31-98d1-c68507ad5620)
+      class DsrGetDCNameEx2Response < BinData::Record
+        attr_reader :opnum
+
+        endian :little
+
+        domain_controller_info_w_ptr :domain_controller_info
+        ndr_uint32                   :error_status
+
+        def initialize_instance
+          super
+          @opnum = DSR_GET_DC_NAME_EX2
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
> However, with some assistance from you, perhaps we can also implement the response.

I got a little carried away and instead of assistance, I ended up with what I'm pretty sure is the finished product.

<details>
<summary>test.rb</summary>
I extracted these hex streams from wireshark while testing the module from rapid7/metasploit-framework#19205 with these changes.

```ruby
$LOAD_PATH.unshift(File.dirname(__FILE__) + '/lib')
require 'bindata'
require 'ruby_smb'
require 'pp'

record = nil

data = '0000000025050000'.scan(/../).map { |x| x.hex.chr }.join
BinData::trace_reading do
  record = RubySMB::Dcerpc::Netlogon::DsrGetDcNameEx2Response.read(data)
end
PP.pp(record.snapshot)


data = '00000200040002000800020001000000812f7f5f1663f24fbdbec96bd5a067e10c00020010000200fdf103e014000200180002002100000000000000210000005c005c005300520056002d004100440044005300300031002e006c00610062007300310063006f006c006c0061006200750030002e006c006f00630061006c00000000000c000000000000000c0000005c005c00310030002e00310030002e0030002e00340000001400000000000000140000006c00610062007300310063006f006c006c0061006200750030002e006c006f00630061006c0000001400000000000000140000006c00610062007300310063006f006c006c0061006200750030002e006c006f00630061006c000000180000000000000018000000440065006600610075006c0074002d00460069007200730074002d0053006900740065002d004e0061006d0065000000180000000000000018000000440065006600610075006c0074002d00460069007200730074002d0053006900740065002d004e0061006d006500000000000000'.scan(/../).map { |x| x.hex.chr }.join
BinData::trace_reading do
  record = RubySMB::Dcerpc::Netlogon::DsrGetDcNameEx2Response.read(data)
end
PP.pp(record.snapshot)
```
</details>

Testing output:

```
obj.domain_controller_info.ref_id => 0
obj.error_status => 1317
{:domain_controller_info=>:null, :error_status=>1317}
obj.domain_controller_info.ref_id => 131072
obj.domain_controller_info.domain_controller_name.ref_id => 131076
obj.domain_controller_info.domain_controller_address.ref_id => 131080
obj.domain_controller_info.domain_controller_address_type => 1
obj.domain_controller_info.domain_guid-internal-.time_low => 1602170753
obj.domain_controller_info.domain_guid-internal-.time_mid => 25366
obj.domain_controller_info.domain_guid-internal-.time_hi_and_version => 20466
obj.domain_controller_info.domain_guid-internal-.clock_seq_hi_and_reserved => 189
obj.domain_controller_info.domain_guid-internal-.clock_seq_low => 190
obj.domain_controller_info.domain_guid-internal-.node[0] => 201
obj.domain_controller_info.domain_guid-internal-.node[1] => 107
obj.domain_controller_info.domain_guid-internal-.node[2] => 213
obj.domain_controller_info.domain_guid-internal-.node[3] => 160
obj.domain_controller_info.domain_guid-internal-.node[4] => 103
obj.domain_controller_info.domain_guid-internal-.node[5] => 225
obj.domain_controller_info.domain_guid => "5f7f2f81-6316-4ff2-bdbe-c96bd5...
obj.domain_controller_info.domain_name.ref_id => 131084
obj.domain_controller_info.dns_forest_name.ref_id => 131088
obj.domain_controller_info.flags => 3758354941
obj.domain_controller_info.dc_site_name.ref_id => 131092
obj.domain_controller_info.client_site_name.ref_id => 131096
obj.domain_controller_info.domain_controller_name.max_count => 33
obj.domain_controller_info.domain_controller_name.offset => 0
obj.domain_controller_info.domain_controller_name.actual_count => 33
obj.domain_controller_info.domain_controller_name => "\\\x00\\\x00S\x00R\x00V\x00-\x...
obj.domain_controller_info.domain_controller_address.max_count => 12
obj.domain_controller_info.domain_controller_address.offset => 0
obj.domain_controller_info.domain_controller_address.actual_count => 12
obj.domain_controller_info.domain_controller_address => "\\\x00\\\x001\x000\x00.\x001\x...
obj.domain_controller_info.domain_name.max_count => 20
obj.domain_controller_info.domain_name.offset => 0
obj.domain_controller_info.domain_name.actual_count => 20
obj.domain_controller_info.domain_name => "l\x00a\x00b\x00s\x001\x00c\x00...
obj.domain_controller_info.dns_forest_name.max_count => 20
obj.domain_controller_info.dns_forest_name.offset => 0
obj.domain_controller_info.dns_forest_name.actual_count => 20
obj.domain_controller_info.dns_forest_name => "l\x00a\x00b\x00s\x001\x00c\x00...
obj.domain_controller_info.dc_site_name.max_count => 24
obj.domain_controller_info.dc_site_name.offset => 0
obj.domain_controller_info.dc_site_name.actual_count => 24
obj.domain_controller_info.dc_site_name => "D\x00e\x00f\x00a\x00u\x00l\x00...
obj.domain_controller_info.client_site_name.max_count => 24
obj.domain_controller_info.client_site_name.offset => 0
obj.domain_controller_info.client_site_name.actual_count => 24
obj.domain_controller_info.client_site_name => "D\x00e\x00f\x00a\x00u\x00l\x00...
obj.error_status => 0
{:domain_controller_info=>
  {:domain_controller_name=>"\\\\SRV-ADDS01.labs1collabu0.local",
   :domain_controller_address=>"\\\\10.10.0.4",
   :domain_controller_address_type=>1,
   :domain_guid=>"5f7f2f81-6316-4ff2-bdbe-c96bd5a067e1",
   :domain_name=>"labs1collabu0.local",
   :dns_forest_name=>"labs1collabu0.local",
   :flags=>3758354941,
   :dc_site_name=>"Default-First-Site-Name",
   :client_site_name=>"Default-First-Site-Name"},
 :error_status=>0}
```